### PR TITLE
Prefer xmlpage astext

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
-dist: xenial
+os: linux
+dist: bionic
 language: java
-sudo: false
-install: true
 
 jdk:
-  - opendjk8
+  - opendjk11
 
 script:
   - mvn verify -e -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
+dist: bionic
 language: java
 sudo: false
 install: true
 
 jdk:
-  - oraclejdk7
+  - opendjk8
 
 script:
   - mvn verify -e -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: xenial
 language: java
 sudo: false
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ os: linux
 dist: bionic
 language: java
 
-jdk:
-  - opendjk11
-
 script:
   - mvn verify -e -V
 

--- a/jwebunit-commons-tests/src/main/java/net/sourceforge/jwebunit/tests/FramesAndWindowsTest.java
+++ b/jwebunit-commons-tests/src/main/java/net/sourceforge/jwebunit/tests/FramesAndWindowsTest.java
@@ -139,8 +139,6 @@ public class FramesAndWindowsTest extends JWebUnitAPITestCase {
     @Test public void testGotoInlineFrame() {
         beginAt("InlineFrame.html");
         assertTextPresent("TopFrame");
-        // Is this how it should work? see also the test below
-        assertTextNotPresent("ContentFrame");
         gotoFrame("ContentFrame");
         assertTextPresent("ContentFrame"); // only 'ContentFrame' matches frameset tag too
     }

--- a/jwebunit-commons-tests/src/main/java/net/sourceforge/jwebunit/tests/IElementTest.java
+++ b/jwebunit-commons-tests/src/main/java/net/sourceforge/jwebunit/tests/IElementTest.java
@@ -218,7 +218,9 @@ public class IElementTest extends JWebUnitAPITestCase {
 	    	assertEquals("unchanged", js2.getAttribute("value"));
 	    	
 	    	// change js1's value
+	    	clickElementByXPath("//input[@id='js1']");
 	    	js1.setAttribute("value", testingText);
+	    	clickElementByXPath("//input[@id='js2']");
     	}
     	
     	// refresh the elements and check they have changed

--- a/jwebunit-commons-tests/src/main/java/net/sourceforge/jwebunit/tests/util/JettySetup.java
+++ b/jwebunit-commons-tests/src/main/java/net/sourceforge/jwebunit/tests/util/JettySetup.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.fail;
 /**
  * Sets up and tears down the Jetty servlet engine before and after the tests in
  * the <code>TestSuite</code> have run.
- * 
+ *
  * @author Eelco Hillenius
  */
 public class JettySetup {
@@ -44,14 +44,14 @@ public class JettySetup {
 	 * The Jetty server we are going to use as test server.
 	 */
 	private static Server jettyServer = null;
-	
+
 	private static boolean started = false;
 
 
 	/**
 	 * Starts the Jetty server using the <tt>jetty-test-config.xml</tt> file
 	 * which is loaded using the classloader used to load Jetty.
-	 * 
+	 *
 	 * @see junit.extensions.TestSetup#setUp()
 	 */
 	@BeforeClass
@@ -62,42 +62,42 @@ public class JettySetup {
     			ServerConnector connector = new ServerConnector(jettyServer);
     			connector.setPort(JWebUnitAPITestCase.JETTY_PORT);
     			jettyServer.setConnectors(new Connector[] { connector });
-    
+
     			WebAppContext wah = new WebAppContext();
-    			
+
     			// Handle files encoded in UTF-8
     			MimeTypes mimeTypes = new MimeTypes();
     			mimeTypes.addMimeMapping("html_utf-8", "text/html; charset=UTF-8");
                 mimeTypes.addMimeMapping("txt", "text/plain");
                 mimeTypes.addMimeMapping("bin", "application/octet-stream");
     			wah.setMimeTypes(mimeTypes);
-    			
-    			
+
+
     			HandlerCollection handlers= new HandlerCollection();
     			handlers.setHandlers(new Handler[]{wah, new DefaultHandler()});
-    
+
     			jettyServer.setHandler(wah);
     			HashLoginService myrealm = new HashLoginService("MyRealm");
     			URL config = JettySetup.class.getResource("/jetty-users.properties");
     			myrealm.setConfig(config.toString());
     			jettyServer.addBean(myrealm);
-    			
+
     			wah.setContextPath(JWebUnitAPITestCase.JETTY_URL);
-    
+
     			URL url = JettySetup.class.getResource("/testcases/");
     			wah.setWar(url.toString());
-    			
+
     			jettyServer.start();
-    			
+
     			started = true;
-    
+
     		} catch (Exception e) {
     			e.printStackTrace();
     			fail("Could not start the Jetty server: " + e);
     		}
 	    }
 	}
-	
+
 	protected static void shutdown() throws Exception {
         try {
             jettyServer.stop();

--- a/jwebunit-htmlunit-plugin/pom.xml
+++ b/jwebunit-htmlunit-plugin/pom.xml
@@ -43,13 +43,23 @@
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.27</version>
+            <version>2.36.0</version>
             <exclusions>
               <exclusion>
                 <artifactId>commons-logging</artifactId>
                 <groupId>commons-logging</groupId>
               </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.jwebunit</groupId>

--- a/jwebunit-htmlunit-plugin/pom.xml
+++ b/jwebunit-htmlunit-plugin/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.23</version>
+            <version>2.27</version>
             <exclusions>
               <exclusion>
                 <artifactId>commons-logging</artifactId>

--- a/jwebunit-htmlunit-plugin/src/main/java/net/sourceforge/jwebunit/htmlunit/HtmlUnitTestingEngineImpl.java
+++ b/jwebunit-htmlunit-plugin/src/main/java/net/sourceforge/jwebunit/htmlunit/HtmlUnitTestingEngineImpl.java
@@ -167,7 +167,7 @@ public class HtmlUnitTestingEngineImpl implements ITestingEngine {
   /**
    * The default browser version.
    */
-  private BrowserVersion defaultBrowserVersion = BrowserVersion.FIREFOX_52;
+  private BrowserVersion defaultBrowserVersion = BrowserVersion.getDefault();
 
   /**
      * Should we ignore failing status codes?
@@ -761,7 +761,7 @@ public class HtmlUnitTestingEngineImpl implements ITestingEngine {
       return ((TextPage) page).getContent();
     }
     if (page instanceof XmlPage) {
-      return ((XmlPage) page).getTextContent();
+      return ((XmlPage) page).asText();
     }
     if (page instanceof UnexpectedPage) {
       return ((UnexpectedPage) page).getWebResponse()
@@ -840,8 +840,9 @@ public class HtmlUnitTestingEngineImpl implements ITestingEngine {
      */
     BrowserVersion bv;
     if (testContext.getUserAgent() != null) {
-      bv = BrowserVersion.FIREFOX_52.clone();
-      bv.setUserAgent(testContext.getUserAgent());
+      bv = new BrowserVersion.BrowserVersionBuilder(BrowserVersion.getDefault())
+              .setUserAgent(testContext.getUserAgent())
+              .build();
     } else {
       bv = defaultBrowserVersion; // use default (which includes a full UserAgent string)
     }

--- a/mvnvm.properties
+++ b/mvnvm.properties
@@ -1,0 +1,1 @@
+mvn_version=3.5.4

--- a/pom.xml
+++ b/pom.xml
@@ -434,17 +434,17 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
-                <version>9.2.11.v20150529</version>
+                <version>9.4.5.v20170502</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlet</artifactId>
-                <version>9.2.11.v20150529</version>
+                <version>9.4.5.v20170502</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-webapp</artifactId>
-                <version>9.2.11.v20150529</version>
+                <version>9.4.5.v20170502</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,7 @@
                         <exclude>LICENSE.txt</exclude>
                         <exclude>README.txt</exclude>
                         <exclude>COPYING*</exclude>
+                        <exclude>mvnvm.properties</exclude>
                         <exclude>src/test/clover/clover.license</exclude>
                         <exclude>src/site/resources/images/jwebunit-architecture.odg</exclude>
                         <exclude>src/main/javacc/WebTestCase.jj</exclude>
@@ -413,6 +414,7 @@
     <properties>
         <topDirectoryLocation>.</topDirectoryLocation>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jetty.version>9.4.24.v20191120</jetty.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -433,18 +435,33 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-io</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
-                <version>9.4.5.v20170502</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlet</artifactId>
-                <version>9.4.5.v20170502</version>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-webapp</artifactId>
-                <version>9.4.5.v20170502</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
 * Upgrade to htmlunit 2.36.0, jetty 9.4.24
 * Use XmlPage.asText (new in recent htmlunit) rather than getTextContent, as getTextContent doesn't handle DOCUMENT nodes, and fails our tests that use this code path.
 * Switch to using BrowserVersion.getDefault for the default version, and the BrowserVersionBuilder instead of clone. This will avoid future breaking changes in these code paths with the next htmlunit upgrade to remove another BrowserVersion constant.